### PR TITLE
feat: R-core-devel to R-core

### DIFF
--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -37,7 +37,8 @@ modules:
       - seahorse
       - sushi
       - gnome-text-editor
-      - R-core-devel
+      - R-core
+      # - R-core-devel
     remove:
       # example: removing firefox (in favor of the flatpak)
       # "firefox" is the main package, "firefox-langpacks" is a dependency


### PR DESCRIPTION
R-core-devel is only necessary at the beginning, but once the development environment is created, these packages lose their worth. Therefore, it's better to just layer the package, set up the development environment, then remove it.